### PR TITLE
Set compendium player ownership to observer

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -24,7 +24,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -37,7 +37,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -50,7 +50,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -63,7 +63,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -76,7 +76,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -89,7 +89,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -102,7 +102,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -115,7 +115,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",
@@ -128,7 +128,7 @@
       "banner": "systems/pf2e/assets/compendium-banner/red.webp",
       "system": "pf2e",
       "ownership": {
-        "PLAYER": "LIMITED",
+        "PLAYER": "OBSERVER",
         "ASSISTANT": "OWNER"
       },
       "type": "Item",


### PR DESCRIPTION
Currently the packs are set to limited, which means players can see links to items, but cannot see the compendiums in the sidebar.
Setting them to observer allows players to see the compendiums and their contents, but not edit them