### PR TITLE
Add Howl of the Wild feats

### DIFF
--- a/packs/ac-feats/Billowing_Wings_p83NzvyOMMa5Dgdh.json
+++ b/packs/ac-feats/Billowing_Wings_p83NzvyOMMa5Dgdh.json
@@ -1,0 +1,94 @@
+{
+  "name": "Billowing Wings",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p>You’ve trained your winged companions to gather air in their wings, whipping up a concentrated gust of wind at opponents, potentially staggering them.</p><p>Your companions with wings gain a gust ranged unarmed attack, which deals @Damage[1d4[bludgeoning]] damage with a range of 30 feet and has the air and propulsive traits. On a critical hit, the target is pushed back 5 feet. This is forced movement.</p>"
+    },
+    "rules": [
+      {
+        "key": "Strike",
+        "category": "unarmed",
+        "damage": {
+          "base": {
+            "damageType": "bludgeoning",
+            "dice": 1,
+            "die": "d4"
+          }
+        },
+        "group": "brawling",
+        "label": "Gust",
+        "traits": [
+          "air",
+          "propulsive",
+          "unarmed"
+        ],
+        "range": {
+          "max": 30
+        },
+        "slug": "gust",
+        "img": "systems/pf2e/icons/unarmed-attacks/gust.webp"
+      },
+      {
+        "key": "Note",
+        "selector": "gust-attack-roll",
+        "text": "On a critical hit, the target is pushed back 5 feet. This is forced movement.",
+        "title": "Gust",
+        "outcome": [
+          "criticalSuccess"
+        ]
+      }
+    ],
+    "slug": null,
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Howl of the Wild",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "level": {
+      "value": 12
+    },
+    "category": "ancestryfeature",
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "actionType": {
+      "value": "passive"
+    },
+    "actions": {
+      "value": null
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "location": null
+  },
+  "_id": "p83NzvyOMMa5Dgdh",
+  "img": "systems/pf2e/icons/spells/gust-of-wind.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "TrmQI1up0VFx77Px": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.7.2"
+  },
+  "_key": "!items!p83NzvyOMMa5Dgdh"
+}

--- a/packs/ac-feats/Billowing_Wings_p83NzvyOMMa5Dgdh.json
+++ b/packs/ac-feats/Billowing_Wings_p83NzvyOMMa5Dgdh.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>You’ve trained your winged companions to gather air in their wings, whipping up a concentrated gust of wind at opponents, potentially staggering them.</p><p>Your companions with wings gain a gust ranged unarmed attack, which deals @Damage[1d4[bludgeoning]] damage with a range of 30 feet and has the air and propulsive traits. On a critical hit, the target is pushed back 5 feet. This is forced movement.</p>"
+      "value": "<p>You've trained your winged companions to gather air in their wings, whipping up a concentrated gust of wind at opponents, potentially staggering them.</p><p>Your companions with wings gain a gust ranged unarmed attack, which deals 1d4 bludgeoning damage with a range of 30 feet and has the air and propulsive traits. On a critical hit, the target is pushed back 5 feet. This is forced movement.</p>"
     },
     "rules": [
       {
@@ -19,7 +19,7 @@
           }
         },
         "group": "brawling",
-        "label": "Gust",
+        "label": "PF2E.BattleForm.Attack.Gust",
         "traits": [
           "air",
           "propulsive",
@@ -52,7 +52,7 @@
       "rarity": "common"
     },
     "publication": {
-      "title": "Howl of the Wild",
+      "title": "Pathfinder Howl of the Wild",
       "authors": "",
       "license": "ORC",
       "remaster": true
@@ -60,7 +60,7 @@
     "level": {
       "value": 12
     },
-    "category": "ancestryfeature",
+    "category": "class",
     "onlyLevel1": false,
     "maxTakable": 1,
     "actionType": {

--- a/packs/ac-feats/Ferocious_Charge_0rlvJoRCrpYuBl9Y.json
+++ b/packs/ac-feats/Ferocious_Charge_0rlvJoRCrpYuBl9Y.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>The companion @UUID[Compendium.pf2e.actionspf2e.Bcxarzksqt9ezrs6]{Strides} up to twice its Speed in a straight line and makes an antlers, head, or horn @UUID[Compendium.pf2e.actionspf2e.VjxZFuUXrCU94MWR]{Strike}. If it moved at least 20 feet, it deals an additional @Damage[1d8] damage. This damage increases to @Damage[2d8] if your companion is specialized. The companion can use Ferocious Charge while Burrowing, Climbing, Flying, or Swimming instead of Striding if it has the corresponding movement type.</p>"
+      "value": "<p>The companion Strides up to twice its Speed in a straight line and makes an antlers, head, or horn Strike. If it moved at least 20 feet, it deals an additional 1d8 damage. This damage increases to 2d8 if your companion is specialized. The companion can use Ferocious Charge while Burrowing, Climbing, Flying, or Swimming instead of Striding if it has the corresponding movement type.</p>"
     },
     "rules": [
       {
@@ -57,7 +57,7 @@
       "rarity": "common"
     },
     "publication": {
-      "title": "Howl of the Wild",
+      "title": "Pathfinder Howl of the Wild",
       "authors": "",
       "license": "ORC",
       "remaster": true

--- a/packs/ac-feats/Ferocious_Charge_0rlvJoRCrpYuBl9Y.json
+++ b/packs/ac-feats/Ferocious_Charge_0rlvJoRCrpYuBl9Y.json
@@ -1,0 +1,99 @@
+{
+  "name": "Ferocious Charge",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p>The companion @UUID[Compendium.pf2e.actionspf2e.Bcxarzksqt9ezrs6]{Strides} up to twice its Speed in a straight line and makes an antlers, head, or horn @UUID[Compendium.pf2e.actionspf2e.VjxZFuUXrCU94MWR]{Strike}. If it moved at least 20 feet, it deals an additional @Damage[1d8] damage. This damage increases to @Damage[2d8] if your companion is specialized. The companion can use Ferocious Charge while Burrowing, Climbing, Flying, or Swimming instead of Striding if it has the corresponding movement type.</p>"
+    },
+    "rules": [
+      {
+        "key": "RollOption",
+        "option": "ferocious-charge",
+        "toggleable": true
+      },
+      {
+        "key": "DamageDice",
+        "diceNumber": 1,
+        "dieSize": "d8",
+        "selector": [
+          "antler-damage",
+          "horn-damage",
+          "head-damage",
+          "headbutt-damage"
+        ],
+        "predicate": [
+          {
+            "not": "self:specialized"
+          },
+          "ferocious-charge"
+        ]
+      },
+      {
+        "key": "DamageDice",
+        "diceNumber": 2,
+        "dieSize": "d8",
+        "selector": [
+          "antler-damage",
+          "horn-damage",
+          "head-damage",
+          "headbutt-damage"
+        ],
+        "predicate": [
+          "self:specialized",
+          "ferocious-charge"
+        ]
+      }
+    ],
+    "slug": null,
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Howl of the Wild",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "level": {
+      "value": 10
+    },
+    "category": "ancestryfeature",
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "actionType": {
+      "value": "action"
+    },
+    "actions": {
+      "value": 2
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "location": null
+  },
+  "_id": "0rlvJoRCrpYuBl9Y",
+  "img": "systems/pf2e/icons/unarmed-attacks/horn.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "TrmQI1up0VFx77Px": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.7.2"
+  },
+  "_key": "!items!0rlvJoRCrpYuBl9Y"
+}

--- a/packs/ac-feats/Heightened_Instincts_V8qaydggB3odZM3w.json
+++ b/packs/ac-feats/Heightened_Instincts_V8qaydggB3odZM3w.json
@@ -1,0 +1,69 @@
+{
+  "name": "Heightened Instincts",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><span style=\"font-family:Roboto, sans-serif\">You’ve worked to sharpen your companions’ instincts to supernatural levels. When one of your companions rolls a success on a saving throw, it gets a critical success instead.</span></p>"
+    },
+    "rules": [
+      {
+        "key": "AdjustDegreeOfSuccess",
+        "selector": "saving-throw",
+        "adjustment": {
+          "success": "one-degree-better"
+        }
+      }
+    ],
+    "slug": null,
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Howl of the Wild",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "level": {
+      "value": 18
+    },
+    "category": "ancestryfeature",
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "actionType": {
+      "value": "passive"
+    },
+    "actions": {
+      "value": null
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "location": null
+  },
+  "_id": "V8qaydggB3odZM3w",
+  "img": "systems/pf2e/icons/spells/ancestral-defense.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "TrmQI1up0VFx77Px": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.7.2"
+  },
+  "_key": "!items!V8qaydggB3odZM3w"
+}

--- a/packs/ac-feats/Heightened_Instincts_V8qaydggB3odZM3w.json
+++ b/packs/ac-feats/Heightened_Instincts_V8qaydggB3odZM3w.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p><span style=\"font-family:Roboto, sans-serif\">You’ve worked to sharpen your companions’ instincts to supernatural levels. When one of your companions rolls a success on a saving throw, it gets a critical success instead.</span></p>"
+      "value": "<p>You've worked to sharpen your companions' instincts to supernatural levels. When one of your companions rolls a success on a saving throw, it gets a critical success instead.</p>"
     },
     "rules": [
       {
@@ -27,7 +27,7 @@
       "rarity": "common"
     },
     "publication": {
-      "title": "Howl of the Wild",
+      "title": "Pathfinder Howl of the Wild",
       "authors": "",
       "license": "ORC",
       "remaster": true

--- a/packs/ac-feats/Nature_s_Precision_wqoI2x7clxJXGw8A.json
+++ b/packs/ac-feats/Nature_s_Precision_wqoI2x7clxJXGw8A.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>Your companions pick at an enemy's weak points. When your companion strikes a @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{Off-Guard} creature with an agile or finesse unarmed attack, it deals an additional @Damage[1d4[precision]] damage (@Damage[2d4[precision]] if the animal companion is specialized). If the companion already deals precision damage, combine the precision damage.</p>"
+      "value": "<p>Your companions pick at an enemy's weak points. When your companion strikes a @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{Off-Guard} creature with an agile or finesse unarmed attack, it deals an additional 1d4 precision damage (2d4 if the animal companion is specialized). If the companion already deals precision damage, combine the precision damage.</p>"
     },
     "rules": [
       {
@@ -56,7 +56,7 @@
       "rarity": "common"
     },
     "publication": {
-      "title": "Howl of the Wild",
+      "title": "Pathfinder Howl of the Wild",
       "authors": "",
       "license": "ORC",
       "remaster": true

--- a/packs/ac-feats/Nature_s_Precision_wqoI2x7clxJXGw8A.json
+++ b/packs/ac-feats/Nature_s_Precision_wqoI2x7clxJXGw8A.json
@@ -1,0 +1,98 @@
+{
+  "name": "Nature's Precision",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p>Your companions pick at an enemy's weak points. When your companion strikes a @UUID[Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg]{Off-Guard} creature with an agile or finesse unarmed attack, it deals an additional @Damage[1d4[precision]] damage (@Damage[2d4[precision]] if the animal companion is specialized). If the companion already deals precision damage, combine the precision damage.</p>"
+    },
+    "rules": [
+      {
+        "key": "DamageDice",
+        "selector": "unarmed-damage",
+        "diceNumber": 1,
+        "dieSize": "d4",
+        "category": "precision",
+        "predicate": [
+          {
+            "or": [
+              "item:trait:agile",
+              "item:trait:finesse"
+            ]
+          },
+          {
+            "not": "self:specialized"
+          },
+          "target:condition:off-guard"
+        ]
+      },
+      {
+        "key": "DamageDice",
+        "selector": "unarmed-damage",
+        "diceNumber": 2,
+        "dieSize": "d4",
+        "category": "precision",
+        "predicate": [
+          {
+            "or": [
+              "item:trait:agile",
+              "item:trait:finesse"
+            ]
+          },
+          "self:specialized",
+          "target:condition:off-guard"
+        ]
+      }
+    ],
+    "slug": null,
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Howl of the Wild",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "level": {
+      "value": 6
+    },
+    "category": "ancestryfeature",
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "actionType": {
+      "value": "passive"
+    },
+    "actions": {
+      "value": null
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "location": null
+  },
+  "_id": "wqoI2x7clxJXGw8A",
+  "img": "systems/pf2e/icons/features/classes/ranger-expertise.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "TrmQI1up0VFx77Px": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.7.2"
+  },
+  "_key": "!items!wqoI2x7clxJXGw8A"
+}

--- a/packs/ac-feats/Running_Kick_fhgEJVsBNMKu75s5.json
+++ b/packs/ac-feats/Running_Kick_fhgEJVsBNMKu75s5.json
@@ -1,0 +1,61 @@
+{
+  "name": "Running Kick",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p>This companion @UUID[Compendium.pf2e.actionspf2e.Bcxarzksqt9ezrs6]{Strides} up to twice its Speed and makes a hoof, foot, or talon @UUID[Compendium.pf2e.actionspf2e.VjxZFuUXrCU94MWR]{Strike} at any point during the movement. This movement doesn’t provoke reactions from a creature damaged by the Strike.</p>"
+    },
+    "rules": [],
+    "slug": null,
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Howl of the Wild",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "level": {
+      "value": 10
+    },
+    "category": "ancestryfeature",
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "actionType": {
+      "value": "action"
+    },
+    "actions": {
+      "value": 2
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "location": null
+  },
+  "_id": "fhgEJVsBNMKu75s5",
+  "img": "systems/pf2e/icons/unarmed-attacks/foot.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "TrmQI1up0VFx77Px": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.7.2"
+  },
+  "_key": "!items!fhgEJVsBNMKu75s5"
+}

--- a/packs/ac-feats/Running_Kick_fhgEJVsBNMKu75s5.json
+++ b/packs/ac-feats/Running_Kick_fhgEJVsBNMKu75s5.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>This companion @UUID[Compendium.pf2e.actionspf2e.Bcxarzksqt9ezrs6]{Strides} up to twice its Speed and makes a hoof, foot, or talon @UUID[Compendium.pf2e.actionspf2e.VjxZFuUXrCU94MWR]{Strike} at any point during the movement. This movement doesn’t provoke reactions from a creature damaged by the Strike.</p>"
+      "value": "<p>This companion Strides up to twice its Speed and makes a hoof, foot, or talon Strike at any point during the movement. This movement doesn't provoke reactions from a creature damaged by the Strike.</p>"
     },
     "rules": [],
     "slug": null,
@@ -19,7 +19,7 @@
       "rarity": "common"
     },
     "publication": {
-      "title": "Howl of the Wild",
+      "title": "Pathfinder Howl of the Wild",
       "authors": "",
       "license": "ORC",
       "remaster": true

--- a/packs/ac-feats/Sinking_Jaws_by5W9auq2eWT3vZp.json
+++ b/packs/ac-feats/Sinking_Jaws_by5W9auq2eWT3vZp.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p><strong>Requirements</strong> This companion has a creature grabbed or restrained with its jaws or fangs</p><hr /><p><strong>Effect</strong> This companion’s grabbed or restrained foe takes piercing damage equal to the companion’s level plus Strength modifier</p><p>@Damage[(@actor.level + @actor.abilities.str.mod)[piercing]]{Leveled Piercing Damage}</p>"
+      "value": "<p><strong>Requirements</strong> This companion has a creature grabbed or restrained with its jaws or fangs</p><hr /><p><strong>Effect</strong> This companion's grabbed or restrained foe takes piercing damage equal to the companion's level plus Strength modifier (@Damage[(@actor.level + @actor.abilities.str.mod)[piercing]])</p>"
     },
     "rules": [],
     "slug": null,
@@ -19,7 +19,7 @@
       "rarity": "common"
     },
     "publication": {
-      "title": "Howl of the Wild",
+      "title": "Pathfinder Howl of the Wild",
       "authors": "",
       "license": "ORC",
       "remaster": true

--- a/packs/ac-feats/Sinking_Jaws_by5W9auq2eWT3vZp.json
+++ b/packs/ac-feats/Sinking_Jaws_by5W9auq2eWT3vZp.json
@@ -1,0 +1,61 @@
+{
+  "name": "Sinking Jaws",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p><strong>Requirements</strong> This companion has a creature grabbed or restrained with its jaws or fangs</p><hr /><p><strong>Effect</strong> This companion’s grabbed or restrained foe takes piercing damage equal to the companion’s level plus Strength modifier</p><p>@Damage[(@actor.level + @actor.abilities.str.mod)[piercing]]{Leveled Piercing Damage}</p>"
+    },
+    "rules": [],
+    "slug": null,
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Howl of the Wild",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "level": {
+      "value": 10
+    },
+    "category": "ancestryfeature",
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "actionType": {
+      "value": "action"
+    },
+    "actions": {
+      "value": 1
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "location": null
+  },
+  "_id": "by5W9auq2eWT3vZp",
+  "img": "systems/pf2e/icons/unarmed-attacks/jaws.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "TrmQI1up0VFx77Px": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.7.2"
+  },
+  "_key": "!items!by5W9auq2eWT3vZp"
+}

--- a/packs/ac-feats/Sweeping_Tail_WCnx9f3Ghtpk9DD0.json
+++ b/packs/ac-feats/Sweeping_Tail_WCnx9f3Ghtpk9DD0.json
@@ -1,0 +1,61 @@
+{
+  "name": "Sweeping Tail",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p>This companion makes two tail @UUID[Compendium.pf2e.actionspf2e.VjxZFuUXrCU94MWR]{Strikes} against different creatures within its reach, increasing its multiple attack penalty as normal. On a hit, it pushes a target back 5 feet or 10 feet on a critical hit. This is forced movement.</p>"
+    },
+    "rules": [],
+    "slug": null,
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Howl of the Wild",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "level": {
+      "value": 10
+    },
+    "category": "ancestryfeature",
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "actionType": {
+      "value": "action"
+    },
+    "actions": {
+      "value": 2
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "location": null
+  },
+  "_id": "WCnx9f3Ghtpk9DD0",
+  "img": "systems/pf2e/icons/unarmed-attacks/tail.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "TrmQI1up0VFx77Px": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.7.2"
+  },
+  "_key": "!items!WCnx9f3Ghtpk9DD0"
+}

--- a/packs/ac-feats/Sweeping_Tail_WCnx9f3Ghtpk9DD0.json
+++ b/packs/ac-feats/Sweeping_Tail_WCnx9f3Ghtpk9DD0.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>This companion makes two tail @UUID[Compendium.pf2e.actionspf2e.VjxZFuUXrCU94MWR]{Strikes} against different creatures within its reach, increasing its multiple attack penalty as normal. On a hit, it pushes a target back 5 feet or 10 feet on a critical hit. This is forced movement.</p>"
+      "value": "<p>This companion makes two tail Strikes against different creatures within its reach, increasing its multiple attack penalty as normal. On a hit, it pushes a target back 5 feet or 10 feet on a critical hit. This is forced movement.</p>"
     },
     "rules": [],
     "slug": null,
@@ -19,7 +19,7 @@
       "rarity": "common"
     },
     "publication": {
-      "title": "Howl of the Wild",
+      "title": "Pathfinder Howl of the Wild",
       "authors": "",
       "license": "ORC",
       "remaster": true

--- a/packs/ac-feats/Vicious_Rend_PG5ndHwkPEyjJ70k.json
+++ b/packs/ac-feats/Vicious_Rend_PG5ndHwkPEyjJ70k.json
@@ -1,0 +1,61 @@
+{
+  "name": "Vicious Rend",
+  "type": "feat",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p>Make two claw, fist, pincer, or talon @UUID[Compendium.pf2e.actionspf2e.VjxZFuUXrCU94MWR]{Strikes} against the same target, applying the multiple attack penalty as normal. If both Strikes hit, the target takes an additional @Damage[1d6[bleed, persistent]]{1d6 persistent bleed} damage. This damage increases to @Damage[2d6[bleed, persistent]]{2d6} if your companion is specialized.</p>"
+    },
+    "rules": [],
+    "slug": null,
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": [],
+      "rarity": "common"
+    },
+    "publication": {
+      "title": "Howl of the Wild",
+      "authors": "",
+      "license": "ORC",
+      "remaster": true
+    },
+    "level": {
+      "value": 10
+    },
+    "category": "ancestryfeature",
+    "onlyLevel1": false,
+    "maxTakable": 1,
+    "actionType": {
+      "value": "action"
+    },
+    "actions": {
+      "value": 2
+    },
+    "prerequisites": {
+      "value": []
+    },
+    "location": null
+  },
+  "_id": "PG5ndHwkPEyjJ70k",
+  "img": "systems/pf2e/icons/unarmed-attacks/claw.webp",
+  "folder": null,
+  "sort": 0,
+  "ownership": {
+    "default": 0,
+    "TrmQI1up0VFx77Px": 3
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.331",
+    "systemId": "pf2e",
+    "systemVersion": "6.7.2"
+  },
+  "_key": "!items!PG5ndHwkPEyjJ70k"
+}

--- a/packs/ac-feats/Vicious_Rend_PG5ndHwkPEyjJ70k.json
+++ b/packs/ac-feats/Vicious_Rend_PG5ndHwkPEyjJ70k.json
@@ -5,7 +5,7 @@
   "system": {
     "description": {
       "gm": "",
-      "value": "<p>Make two claw, fist, pincer, or talon @UUID[Compendium.pf2e.actionspf2e.VjxZFuUXrCU94MWR]{Strikes} against the same target, applying the multiple attack penalty as normal. If both Strikes hit, the target takes an additional @Damage[1d6[bleed, persistent]]{1d6 persistent bleed} damage. This damage increases to @Damage[2d6[bleed, persistent]]{2d6} if your companion is specialized.</p>"
+      "value": "<p>Make two claw, fist, pincer, or talon Strikes against the same target, applying the multiple attack penalty as normal. If both Strikes hit, the target takes an additional @Damage[1d6[bleed]] damage. This damage increases to 2d6 if your companion is specialized.</p>"
     },
     "rules": [],
     "slug": null,
@@ -19,7 +19,7 @@
       "rarity": "common"
     },
     "publication": {
-      "title": "Howl of the Wild",
+      "title": "Pathfinder Howl of the Wild",
       "authors": "",
       "license": "ORC",
       "remaster": true


### PR DESCRIPTION
Automated Animal Companions ancestry features for the Beastmaster feats added in Howl of the Wild:
- Nature's Precision
- Ferocious Charge
- Running Kick
- Sinking Jaws
- Sweeping Tail
- Vicious Rend
- Billowing Wings
- Heightened Instincts