### PR TITLE
Fix localization keys

### DIFF
--- a/packs/ac-evolution-feats/Vibration_Sense__CC__4iJgmh1XmMGdzSF8.json
+++ b/packs/ac-evolution-feats/Vibration_Sense__CC__4iJgmh1XmMGdzSF8.json
@@ -33,7 +33,7 @@
           }
         ],
         "force": false,
-        "label": "PF2E.SensesTremorsense"
+        "label": "PF2E.Actor.Creature.Sense.Type.Tremorsense"
       },
       {
         "acuity": "imprecise",

--- a/packs/ac-features/Breath_Weapon_I8fG26JJS29ZYwfZ.json
+++ b/packs/ac-features/Breath_Weapon_I8fG26JJS29ZYwfZ.json
@@ -42,7 +42,7 @@
         ],
         "flag": "breathWeapon",
         "key": "ChoiceSet",
-        "prompt": "PF2E.UI.RuleElemnts.ChoiceSet.Prompt"
+        "prompt": "PF2E.UI.RuleElements.ChoiceSet.Prompt"
       },
       {
         "key": "GrantItem",


### PR DESCRIPTION
There is also a broken key `PF2E.Weapon.Base.claws` in Sundaflora because plural claws doesn't exist in the system localization file (its "claws" attack image path also leads to a nonexistent file).