### PR TITLE
Fix Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,17 +9,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+
       # get part of the tag after the `v`
       - name: Extract tag version number
         id: get-version
         run: echo "version-without-v=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Get Module JSON
         id: set_var
         run: |
           echo "PACKAGE_JSON=$(jq -c . < module.json)" >> $GITHUB_OUTPUT
+
       - name: Get Module Title
         id: title
         run: echo "title=${{ fromJson(steps.set_var.outputs.PACKAGE_JSON).title }}" >> "$GITHUB_OUTPUT"
+
       # Substitute the Manifest and Download URLs in the `module.json`.
       - name: Substitute Manifest and Download Links For Versioned Ones
         id: sub_manifest_link_version
@@ -30,9 +35,14 @@ jobs:
           version: ${{ steps.get-version.outputs.version-without-v }}
           manifest: https://github.com/${{ github.repository }}/releases/latest/download/module.json
           download: https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/module.zip
+
+      - name: Build
+        run: npm run build
+
       # Create a folder containing all the module stuff and zip it for the release
       - name: Create Zip
         run: zip -r9 ./module.zip build/
+
       - name: Update Release with Files
         id: create_version_release
         uses: ncipollo/release-action@v1
@@ -44,6 +54,7 @@ jobs:
           name: ${{ steps.get-version.outputs.version-without-v }}
           body: ${{ steps.changelog.outputs.release-notes }}
           artifacts: './module.json, ./module.zip'
+
       - name: Publish to FoundryVTT
         uses: cs96and/FoundryVTT-release-package@v1.0.2
         if: ${{ !github.event.release.prerelease && env.PACKAGE_TOKEN }}


### PR DESCRIPTION
The script never builds and arguably the `build/` folder should be `.gitignore`d entirely in a separate commit.