### PR TITLE
fix: correct savaga-animal-companion typo in Fiery Leopard predicate (#213)

### DIFF
--- a/packs/ac-ancestries-and-class/Fiery_Leopard_dUAqUKIdieoFVHRp.json
+++ b/packs/ac-ancestries-and-class/Fiery_Leopard_dUAqUKIdieoFVHRp.json
@@ -134,7 +134,7 @@
           {
             "or": [
               "feature:nimble-animal-companion",
-              "feature:savaga-animal-companion"
+              "feature:savage-animal-companion"
             ]
           }
         ],

--- a/packs/sf-ac-ancestries-and-class/Fiery_Leopard_dUAqUKIdieoFVHRp.json
+++ b/packs/sf-ac-ancestries-and-class/Fiery_Leopard_dUAqUKIdieoFVHRp.json
@@ -134,7 +134,7 @@
           {
             "or": [
               "feature:nimble-animal-companion",
-              "feature:savaga-animal-companion"
+              "feature:savage-animal-companion"
             ]
           }
         ],


### PR DESCRIPTION
## What

Fixes the `savaga-animal-companion` → `savage-animal-companion` typo in the Fiery Leopard feature predicate, in both the Pathfinder and Starfinder ancestries-and-class packs.

Closes #213.

## Why

As reported in #213, Fiery Leopard's bonus fire damage is broken for the Savage animal companion because the damage dice predicate references `feature:savaga-animal-companion` (with a stray `a`) instead of `feature:savage-animal-companion`. Since the predicate never matches, the extra fire damage never applies.

## Details

- `packs/ac-ancestries-and-class/Fiery_Leopard_dUAqUKIdieoFVHRp.json`: `feature:savaga-animal-companion` → `feature:savage-animal-companion`
- `packs/sf-ac-ancestries-and-class/Fiery_Leopard_dUAqUKIdieoFVHRp.json`: same fix

Each file contained exactly one occurrence of the typo. The correct spelling `savage-animal-companion` is already used elsewhere in the same predicate lists, confirming the intended value.
